### PR TITLE
Added reportsType input

### DIFF
--- a/securellm/Chart.yaml
+++ b/securellm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4
+version: 0.5
 
 # Subcharts
 dependencies:

--- a/securellm/README.md
+++ b/securellm/README.md
@@ -34,7 +34,8 @@ helm install <release-name> dkubex-helm/securellm -n securellm --create-namespac
 --set imageCredentials.password=<crtoken> \
 --set global.db.wipedata=true \
 --set sllmOpenaiKey=<openaikey> \
---version 0.4 --wait
+--set reportsType="DEFAULT" \
+--version 0.5 --wait
 ```
 
 ##### check status
@@ -70,7 +71,8 @@ helm install <release-name> dkubex-helm/securellm -n securellm --create-namespac
 --set imageCredentials.password=<crtoken> \
 --set global.db.wipedata=true \
 --set sllmOpenaiKey=<oaikey> \
---version 0.4 --wait
+--set reportsType="DEFAULT" \
+--version 0.5 --wait
 
 ```
 
@@ -78,9 +80,9 @@ helm install <release-name> dkubex-helm/securellm -n securellm --create-namespac
 ## Upgrade
 To upgrade securellm, please use the below command with the newly available version of securellm.
 
-#### Upgrade securellm from version 0.3 to 0.4
+#### Upgrade securellm from version 0.4 to 0.5
 ```bash
-helm upgrade <release-name> dkubex-helm/securellm -n securellm --reuse-values --version 0.4 --wait
+helm upgrade <release-name> dkubex-helm/securellm -n securellm --reuse-values --version 0.5 --wait
 ```
 
 ## Uninstallation

--- a/securellm/templates/securellm.yaml
+++ b/securellm/templates/securellm.yaml
@@ -28,7 +28,7 @@ spec:
       - name: securellm-dockerhub-secret
       containers:
       - name: main
-        image: dkubex123/securellm-fe:0.4
+        image: dkubex123/securellm-fe:0.5
         imagePullPolicy: Always
         envFrom:
         - secretRef:
@@ -55,6 +55,8 @@ spec:
           value: "user@dkubex.ai"
         - name: SLLM_USER_PASSWORD
           value: "{{ .Values.sllmAdminPassword }}"
+        - name: REPORTS_TYPE
+          value: "{{ .Values.reportsType }}"
 
 ---
 
@@ -92,14 +94,14 @@ spec:
       initContainers:
       - name: init
         command: ["/opt/db/migrate.sh"]
-        image: dkubex123/securellm-be:0.4
+        image: dkubex123/securellm-be:0.5
         imagePullPolicy: Always
         envFrom:
         - secretRef:
             name: {{ .Values.supabase.db.secretName }}
       containers:
       - name: main
-        image: dkubex123/securellm-be:0.4
+        image: dkubex123/securellm-be:0.5
         imagePullPolicy: Always
         envFrom:
         - secretRef:

--- a/securellm/values.yaml
+++ b/securellm/values.yaml
@@ -20,6 +20,7 @@ global:
 sllmAdminUser: "admin@dkubex.ai"
 sllmAdminPassword: ""
 sllmOpenaiKey: ""
+reportsType: "DEFAULT"
 
 imageCredentials:
   registry: "https://index.docker.io/v1/"


### PR DESCRIPTION
Updated image tags of securellm-fe and securellm-be to 0.5
Added reportsType input ("DEFAULT" | "<customer specific report>")
Based on the value of Reports type, securellm-fe image will render corresponding reports page